### PR TITLE
Bump the swift-snapshot-testing versino

### DIFF
--- a/SimpleProject.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SimpleProject.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,7 +6,7 @@
       "location" : "https://github.com/tdrhq/swift-snapshot-testing",
       "state" : {
         "branch" : "main",
-        "revision" : "1b74847d67b3863718f528c7e7af281a14a7ff18"
+        "revision" : "66b821dd42fc6954d478adb578367703910a7d0a"
       }
     },
     {


### PR DESCRIPTION
I'm not sure if I'm even using swift-package-manager in CI. but bumping it just in case.